### PR TITLE
Fix docker compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Backend Python API source code for abateai.com
 
 ### Installation
 
-First, clone the repo with
+First, clone the repo and change directory into it with
 
 ```bash
 $ git clone https://github.com/ABATEAI/backend.git
+$ cd backend
 ```
 
 Assuming you have installed Docker Desktop, open the application and sign in.
@@ -55,13 +56,19 @@ The development server is started with
 $ docker-compose up -d
 ```
 
+You can also build and start the server with the combined command
+
+```bash
+$ docker-compose up -d --build
+```
+
 Responses from the ABATE AI API that are viewable can be seen at
 `http://localhost:8000/api/<api_path>`.
 
 Any changes to [src/index.py](src/index.py) will show up in the browser
 (if viewable) after refreshing.
 
-Once you are done with development, shut down the development server with
+Once you are done with development, shut down the server with
 
 ```bash
 $ docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 services:
   abateai_api:
     build: .
-    command: ["uvicorn app.index:app --host 0.0.0.0 --port 8000 --reload"]
+    command: ["sh", "-c", "uvicorn app.index:app --host 0.0.0.0 --port 8000 --reload"]
     restart: always
     volumes:
       - ./src:/usr/src/app


### PR DESCRIPTION
The docker compose command has been fixed and the development server now functions correctly again (just had to add `sh -c` before the call to `uvicorn`). Tested fix locally.

Also added some README.md updates from the frontend repo for consistency.